### PR TITLE
Add variables and data types page

### DIFF
--- a/pages/basic-programing/python-basics.html
+++ b/pages/basic-programing/python-basics.html
@@ -16,7 +16,7 @@
         <div class="content">
             <h2>기본 문법</h2>
             <ul class="skills-list">
-                <li>변수와 자료형</li>
+                <li><a href="./variables-and-data-types.html">변수와 자료형</a></li>
                 <li>조건문과 반복문</li>
                 <li>함수 정의와 호출</li>
                 <li>모듈과 패키지 활용</li>

--- a/pages/basic-programing/variables-and-data-types.html
+++ b/pages/basic-programing/variables-and-data-types.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>파이썬 변수와 자료형</title>
+    <link rel="stylesheet" href="../../css/styles.css" />
+    <style>
+        pre.code-block {
+            background-color: #2d2d2d;
+            color: #f8f8f2;
+            padding: 15px;
+            border-radius: 8px;
+            overflow-x: auto;
+            font-family: "Courier New", Courier, monospace;
+            line-height: 1.4;
+            margin-bottom: 20px;
+        }
+        pre.code-block code {
+            display: block;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h1>파이썬 변수와 자료형</h1>
+            <p>기본 변수 사용법과 주요 자료형 살펴보기</p>
+            <p><a href="../../index.html">← 메인 페이지로 돌아가기</a></p>
+        </div>
+        <div class="content">
+            <h2>변수란?</h2>
+            <p>변수는 데이터를 저장하기 위한 이름표입니다. 파이썬에서는 변수를 선언할 때 별도의 키워드가 필요하지 않습니다.</p>
+            <pre class="code-block"><code># 변수 선언과 값 할당
+message = "Hello, Python!"
+count = 10
+pi = 3.14
+</code></pre>
+
+            <h2>자료형 살펴보기</h2>
+            <p>파이썬의 기본 자료형에는 문자열(<code>str</code>), 정수(<code>int</code>), 실수(<code>float</code>), 불린(<code>bool</code>) 등이 있습니다. <code>type()</code> 함수를 사용하면 변수의 자료형을 확인할 수 있습니다.</p>
+            <pre class="code-block"><code># 기본 자료형과 type() 함수
+name = "Alice"
+age = 25
+height = 172.5
+is_student = True
+
+print(type(name))       # <class 'str'>
+print(type(age))        # <class 'int'>
+print(type(height))     # <class 'float'>
+print(type(is_student)) # <class 'bool'>
+</code></pre>
+
+            <h2>리스트와 딕셔너리</h2>
+            <p>여러 값을 하나의 변수에 담을 수 있는 자료형으로 리스트와 딕셔너리가 있습니다.</p>
+            <pre class="code-block"><code># 리스트와 딕셔너리 사용 예
+fruits = ["apple", "banana", "cherry"]
+person = {"name": "Alice", "age": 25}
+
+print(fruits[0])       # apple
+print(person["name"])  # Alice
+</code></pre>
+        </div>
+    </div>
+    <script src="../../js/script.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create detailed page about Python variables and data types with code examples
- link to the new page from the Python basics page

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684d110be0b8832b8ea39b8875d79cd8